### PR TITLE
Add cycles data

### DIFF
--- a/cycles.json
+++ b/cycles.json
@@ -1,0 +1,136 @@
+[
+    {
+        "id": "variants",
+        "name": "Variants",
+        "packs": [
+            "VDS"
+        ]
+    },
+    {
+        "id": "core",
+        "name": "Core Set",
+        "packs": [
+            "Core"
+        ]
+    },
+    {
+        "id": "westeros",
+        "name": "Westeros Cycle",
+        "packs": [
+            "TtB",
+            "TRtW",
+            "TKP",
+            "NMG",
+            "CoW",
+            "TS"
+        ]
+    },
+    {
+        "id": "wolves",
+        "name": "Wolves of the North",
+        "packs": [
+            "WotN"
+        ]
+    },
+    {
+        "id": "war",
+        "name": "War of Five Kings Cycle",
+        "packs": [
+            "AtSK",
+            "CtA",
+            "FFH",
+            "TIMC",
+            "GoH",
+            "TC"
+        ]
+    },
+    {
+        "id": "lions",
+        "name": "Lions of Casterly Rock",
+        "packs": [
+            "LoCR"
+        ]
+    },
+    {
+        "id": "bng",
+        "name": "Blood and Gold",
+        "packs": [
+            "AMAF",
+            "GtR",
+            "TFoA",
+            "TRW",
+            "OR",
+            "TBWB"
+        ]
+    },
+    {
+        "id": "watchers",
+        "name": "Watchers on the Wall",
+        "packs": [
+            "WotW"
+        ]
+    },
+    {
+        "id": "foc",
+        "name": "Flight of Crows",
+        "packs": [
+            "TAK",
+            "JtO",
+            "Km",
+            "FotOG",
+            "TFM",
+            "SAT"
+        ]
+    },
+    {
+        "id": "thorns",
+        "name": "House of Thorns",
+        "packs": [
+            "HoT"
+        ]
+    },
+    {
+        "id": "sands",
+        "name": "Sands of Dorne",
+        "packs": [
+            "SoD"
+        ]
+    },
+    {
+        "id": "dos",
+        "name": "Dance of Shadows",
+        "packs": [
+            "TSC",
+            "TMoW",
+            "SoKL",
+            "MoD",
+            "IDP",
+            "DitD"
+        ]
+    },
+    {
+        "id": "isles",
+        "name": "Kings of the Isles",
+        "packs": [
+            "KotI"
+        ]
+    },
+    {
+        "id": "landing",
+        "name": "King's Landing",
+        "packs": [
+            "AtG",
+            "CoS",
+            "PoS",
+            "BtRK",
+            "TB"
+        ]
+    },
+    {
+        "id": "storm",
+        "name": "Fury of the Storm",
+        "packs": [
+            "FotS"
+        ]
+    }
+]

--- a/cycles.schema.json
+++ b/cycles.schema.json
@@ -1,0 +1,28 @@
+{
+    "items": {
+        "additionalProperties": false,
+        "properties": {
+            "id": {
+                "minLength": 1,
+                "type": "string"
+            },
+            "name": {
+                "minLength": 1,
+                "type": "string"
+            },
+            "packs": {
+                "type": "array",
+                "items": {
+                    "minLength": 1,
+                    "type": "string"
+                }
+            }
+        },
+        "required": [
+            "id",
+            "name",
+            "packs"
+        ]
+    },
+    "type": "array"
+}

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const ThronetekiCyclesValidator = require('../src/ThronetekiCyclesValidator');
 const ThronetekiPackValidator = require('../src/ThronetekiPackValidator.js');
 const BasicValidator = require('../src/BasicValidator.js');
 
@@ -16,6 +17,15 @@ for(let file of packFiles) {
         console.error(`Errors in ${file}:\n${result.errors.join('\n')}`);
         valid = false;
     }
+}
+
+let cyclesValidator = new ThronetekiCyclesValidator({ packFiles });
+let cycles = require('../cycles.json');
+let cyclesResult = cyclesValidator.validate(cycles);
+
+if(!cyclesResult.valid) {
+    console.error(`Errors in cycles.json:\n${cyclesResult.errors.join('\n')}`);
+    valid = false;
 }
 
 let restrictedListValidator = new BasicValidator(require('../restricted-list.schema.json'));

--- a/src/ThronetekiCyclesValidator.js
+++ b/src/ThronetekiCyclesValidator.js
@@ -1,0 +1,69 @@
+const Validator = require('jsonschema').Validator;
+
+class ThronetekiCyclesValidator {
+    constructor({ packFiles }) {
+        this.cyclesSchema = require('../cycles.schema.json');
+        this.validator = this.createValidator();
+        this.packFiles = packFiles || [];
+    }
+
+    createValidator() {
+        let validator = new Validator();
+        validator.addSchema(this.cyclesSchema, '/cycles.schema.json');
+        return validator;
+    }
+
+    validate(cycles) {
+        let results = this.validator.validate(cycles, this.cyclesSchema, { nestedErrors: true });
+        let manualErrors = this.getErrorsForCycles(cycles);
+        return {
+            errors: manualErrors.concat(results.errors.map(error => this.addCycleInfoToError(cycles, error))),
+            valid: results.valid && manualErrors.length === 0
+        };
+    }
+
+    getErrorsForCycles(cycles) {
+        let errors = [];
+        let referencedPacks = [];
+        let uniqueCycles = new Set();
+
+        for(let cycle of cycles) {
+            if(uniqueCycles.has(cycle.id)) {
+                errors.push(`Cycle ${cycle.name} (${cycle.id}) must have a unique ID`);
+            }
+
+            uniqueCycles.add(cycle.id);
+
+            for(let pack of cycle.packs) {
+                let pathFileName = `${pack}.json`;
+                if(!this.packFiles.includes(pathFileName)) {
+                    errors.push(`Cycle ${cycle.name} (${cycle.id}) references pack ${pack} but there is no JSON file`);
+                }
+                referencedPacks.push(pathFileName);
+            }
+        }
+
+        let unreferencedPacks = this.packFiles.filter(packFile => !referencedPacks.includes(packFile));
+
+        for(let packFile of unreferencedPacks) {
+            errors.push(`Pack file ${packFile} is not referenced in a cycle`);
+        }
+
+        return errors;
+    }
+
+    addCycleInfoToError(cycles, error) {
+        let message = error.toString();
+        let match = message.match(/instance\[(\d+)\]/);
+        if(!match) {
+            return message;
+        }
+
+        let cycleIndex = parseInt(match[1]);
+        let cycle = cycles[cycleIndex];
+
+        return message.replace(match[0], `'${cycle.name} (${cycle.id})'`);
+    }
+}
+
+module.exports = ThronetekiCyclesValidator;


### PR DESCRIPTION
Progress towards ThronesDB/thronesdb#314

@stopfstedt Let me know what you think about this format. One thing that bothers me are the single-pack cycles for deluxe boxes, but it's inline with what ThronesDB does today. I'm unsure if there's any reasonable alternative though. The "position" property from ThronesDB is now implicit in the order of the array.

One slight data change I made is renamed the existing Valyrian Draft Set "cycle" to "Variants" so that we can potentially put more things (like Kingsmoot) underneath it.