### PR TITLE
Dragons of the East announcement pt 1.

### DIFF
--- a/cycles.json
+++ b/cycles.json
@@ -133,5 +133,12 @@
         "packs": [
             "FotS"
         ]
+    },
+    {
+        "id": "dragons",
+        "name": "Dragons of the East",
+        "packs": [
+            "DotE"
+        ]
     }
 ]

--- a/packs/DotE.json
+++ b/packs/DotE.json
@@ -5,7 +5,7 @@
     "releaseDate": null,
     "cards": [
         {
-            "code": "16001",
+            "code": "15001",
             "type": "character",
             "name": "Daenerys Targaryen",
             "unique": true,
@@ -29,7 +29,7 @@
             "illustrator": "Aleksander Karcz"
         },
         {
-            "code": "16012",
+            "code": "15012",
             "type": "character",
             "name": "Captain Groleo",
             "unique": true,
@@ -51,7 +51,7 @@
             "illustrator": "Scott Altmann"
         },
         {
-            "code": "16019",
+            "code": "15019",
             "type": "attachment",
             "name": "Khaleesi",
             "unique": true,
@@ -66,7 +66,7 @@
             "illustrator": "Tomasz Jedruszek"
         },
         {
-            "code": "16020",
+            "code": "15020",
             "type": "attachment",
             "name": "Dragon Egg",
             "unique": false,
@@ -82,7 +82,7 @@
             "illustrator": "Julepe"
         },
         {
-            "code": "16026",
+            "code": "15026",
             "type": "character",
             "name": "Dragonstone Convert",
             "unique": false,
@@ -104,7 +104,7 @@
             "illustrator": "Magali Villeneuve"
         },
         {
-            "code": "16029",
+            "code": "15029",
             "type": "character",
             "name": "Ser Meryn Trant",
             "unique": true,
@@ -127,7 +127,7 @@
             "illustrator": "Alexandre Dainche"
         },
         {
-            "code": "16030",
+            "code": "15030",
             "type": "location",
             "name": "The Red Keep",
             "unique": true,
@@ -142,7 +142,7 @@
             "illustrator": "Logan Feliciano"
         },
         {
-            "code": "16041",
+            "code": "15041",
             "type": "character",
             "name": "Tormund Giantsbane",
             "unique": true,

--- a/packs/DotE.json
+++ b/packs/DotE.json
@@ -1,0 +1,167 @@
+{
+    "cgdbId": 59,
+    "code": "DotE",
+    "name": "Dragons of the East",
+    "releaseDate": null,
+    "cards": [
+        {
+            "code": "16001",
+            "type": "character",
+            "name": "Daenerys Targaryen",
+            "unique": true,
+            "faction": "targaryen",
+            "loyal": true,
+            "cost": 8,
+            "icons": {
+                "military": false,
+                "intrigue": true,
+                "power": true
+            },
+            "strength": 5,
+            "traits": [
+                "Lady",
+                "Queen",
+                "Stormborn"
+            ],
+            "text": "<b>Action:</b> Search the top 10 cards of your deck for an attachment or <i>Dragon</i> card, reveal it, and add it to your hand (you may put it into play instead if its printed cost is 3 or lower). Shuffle your deck. (Limit once per round.)",
+            "flavor": "\"Why do the gods make kings and queens, if not to protect the ones woho can't protect themselves?\"",
+            "deckLimit": 3,
+            "illustrator": "Aleksander Karcz"
+        },
+        {
+            "code": "16012",
+            "type": "character",
+            "name": "Captain Groleo",
+            "unique": true,
+            "faction": "targaryen",
+            "loyal": false,
+            "cost": 2,
+            "icons": {
+                "military": false,
+                "intrigue": true,
+                "power": false
+            },
+            "strength": 2,
+            "traits": [
+                "Captain"
+            ],
+            "text": "<b>Reaction:</b> After an attachment enters play, gain 1 gold. (Limit once per phase.)",
+            "flavor": "At first Groleo had wanted the dragons caged and Dany had consented to put his fears at ease, but their misery was so palpable that she soon changed her mind and insisted they be freed.",
+            "deckLimit": 3,
+            "illustrator": "Scott Altmann"
+        },
+        {
+            "code": "16019",
+            "type": "attachment",
+            "name": "Khaleesi",
+            "unique": true,
+            "faction": "targaryen",
+            "loyal": true,
+            "cost": 3,
+            "traits": [
+                "Title"
+            ],
+            "text": "<i>Lady</i> character only.\n<b>Reaction:</b> After you win a challenge in which attached character is participating, kneel Khaleesi to, either: stand attached character, or raise the claim value on your revealed plot card by 1 until the end of the challenge.",
+            "deckLimit": 3,
+            "illustrator": "Tomasz Jedruszek"
+        },
+        {
+            "code": "16020",
+            "type": "attachment",
+            "name": "Dragon Egg",
+            "unique": false,
+            "faction": "targaryen",
+            "loyal": true,
+            "cost": 2,
+            "traits": [
+                "Dragon",
+                "Item"
+            ],
+            "text": "Attached character gains insight.\n<b>Reaction:</b> After the marshaling phase begins, if attached character is Daenerys Targaryen, sacrifice Dragon Egg to search your deck for a <i>Hatchling</i> character and put it into play. Shuffle your deck.",
+            "deckLimit": 3,
+            "illustrator": "Julepe"
+        },
+        {
+            "code": "16026",
+            "type": "character",
+            "name": "Dragonstone Convert",
+            "unique": false,
+            "faction": "baratheon",
+            "loyal": false,
+            "cost": 4,
+            "icons": {
+                "military": false,
+                "intrigue": true,
+                "power": true
+            },
+            "strength": 3,
+            "traits": [
+                "House Florent",
+                "R'hllor"
+            ],
+            "text": "<b>Challenges Action:</b> Name an event. Until the end of the phase, events with that title cannot be played. (Limit once per phase.)",
+            "deckLimit": 3,
+            "illustrator": "Magali Villeneuve"
+        },
+        {
+            "code": "16029",
+            "type": "character",
+            "name": "Ser Meryn Trant",
+            "unique": true,
+            "faction": "lannister",
+            "loyal": false,
+            "cost": 3,
+            "icons": {
+                "military": true,
+                "intrigue": true,
+                "power": false
+            },
+            "strength": 3,
+            "traits": [
+                "Kingsguard",
+                "Knight"
+            ],
+            "text": "<b>Interrupt:</b> When a card is discarded from an opponent's hand, remove it from the game instead of placing it in his or her discard pile.",
+            "flavor": "Ser Meryn Trant simply did not care.",
+            "deckLimit": 3,
+            "illustrator": "Alexandre Dainche"
+        },
+        {
+            "code": "16030",
+            "type": "location",
+            "name": "The Red Keep",
+            "unique": true,
+            "faction": "lannister",
+            "loyal": false,
+            "cost": 4,
+            "traits": [
+                "King's Landing"
+            ],
+            "text": "<b>Interrupt:</b> When the effects of an opponent's triggered character, location, or attachment ability would initiate, kneel The Red Keep to cancel those effects.\n+1 Income.",
+            "deckLimit": 3,
+            "illustrator": "Logan Feliciano"
+        },
+        {
+            "code": "16041",
+            "type": "character",
+            "name": "Tormund Giantsbane",
+            "unique": true,
+            "faction": "neutral",
+            "loyal": false,
+            "cost": 5,
+            "icons": {
+                "military": true,
+                "intrigue": false,
+                "power": true
+            },
+            "strength": 4,
+            "traits": [
+                "Storyteller",
+                "Wildling"
+            ],
+            "text": "Intimidate.\n<b>Reaction:</b> After you win a challenge in which Tormund Giantsbane is participating, place a tale token on him.\n<b>Action:</b> Discard 1 tale token from Tormund Giantsbane to give a <i>Wildling</i> character +2 STR and renown until the end of the phase.",
+            "deckLimit": 3,
+            "illustrator": "Ryan Valle"
+        }
+    ]
+}

--- a/packs/DotE.json
+++ b/packs/DotE.json
@@ -1,5 +1,5 @@
 {
-    "cgdbId": 59,
+    "cgdbId": 53,
     "code": "DotE",
     "name": "Dragons of the East",
     "releaseDate": null,

--- a/packs/DotE.json
+++ b/packs/DotE.json
@@ -24,7 +24,7 @@
                 "Stormborn"
             ],
             "text": "<b>Action:</b> Search the top 10 cards of your deck for an attachment or <i>Dragon</i> card, reveal it, and add it to your hand (you may put it into play instead if its printed cost is 3 or lower). Shuffle your deck. (Limit once per round.)",
-            "flavor": "\"Why do the gods make kings and queens, if not to protect the ones woho can't protect themselves?\"",
+            "flavor": "\"Why do the gods make kings and queens, if not to protect the ones who can't protect themselves?\"",
             "deckLimit": 3,
             "illustrator": "Aleksander Karcz"
         },
@@ -147,7 +147,6 @@
             "name": "Tormund Giantsbane",
             "unique": true,
             "faction": "neutral",
-            "loyal": false,
             "cost": 5,
             "icons": {
                 "military": true,


### PR DESCRIPTION
https://www.fantasyflightgames.com/en/news/2019/7/24/dragons-of-the-east/

~I left Tormund Giantsbane out intentionally, because I couldn't quite make out his card code (despite best squinting efforts).~ His card code is _very likely_ 41, considering the position/codes of neutral characters in previous deluxe boxes. 

Please review, I inferred the pack's `cgdbId` by counting up from FotS, the same goes for the card `code` offset by 16000.