### PR TITLE
Tracks Errata in separate card attributes

### DIFF
--- a/card.schema.json
+++ b/card.schema.json
@@ -15,6 +15,17 @@
                     "enum": ["X", "-"]
                 }
             ]
+        },
+        "erratum": {
+            "type": "object",
+            "properties": {
+                "issuer": { "enum": ["Fantasy Flight Games", "The Conclave"] },
+                "version": { "type": "string", "minLength": 1 },
+                "link": { "type": "string", "format": "uri" },
+                "text": { "type": "string", "minLength": 1 },
+                "notes":  { "type": [ "string", "null" ] }
+            },
+            "required": ["issuer", "version", "text", "notes"]
         }
     },
     "properties": {
@@ -109,6 +120,9 @@
         },
         "unique": {
             "type": "boolean"
+        },
+        "errata": {
+            "items": { "$ref": "#/definitions/erratum" }
         }
     },
     "required": [

--- a/packs/FotS.json
+++ b/packs/FotS.json
@@ -598,9 +598,25 @@
             "traits": [
                 "House Manwoody"
             ],
-            "text": "<b>Reaction:</b> After you lose a [power] challenge by 5 or more STR, kneel and sacrifice Kingsgrave to choose a participating character and return it to its owner's hand. (You may kill that character instead if it has the <i>King</i> trait.)\n<em>Errata from FAQ v2.2</em>",
+            "text": "<b>Reaction:</b> After you lose a [power] challenge by 5 or more STR, kneel and sacrifice Kingsgrave to choose a participating character and return it to its owner's hand. (You may kill that character instead if it has the <i>King</i> trait.)",
             "deckLimit": 3,
-            "illustrator": "Logan Feliciano"
+            "illustrator": "Logan Feliciano",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "<b>Reaction:</b> After you lose a [power] challenge by 5 or more STR, kneel and sacrifice Kingsgrave to choose a participating character and return it to its owner's hand. (You may kill that character instead if it has the <i>King</i> trait.)",
+                    "notes": null
+
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "2.2",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "<b>Reaction:</b> After you lose a [power] challenge by 5 or more STR, kneel and sacrifice Kingsgrave to choose a participating character and return it to its owner's hand. (You may kill that character instead if it has the <i>King</i> trait.)",
+                    "notes": "Card text is improperly formatted; the word \"Kingsgrave\" should not be formatted as a trait."
+                }
+            ]
         },
         {
             "code": "14031",
@@ -709,9 +725,24 @@
             "traits": [
                 "Warhorse"
             ],
-            "text": "Limit 1 copy per character.\nWhile attached character is attacking, it gets +1 STR (+3 STR instead if it has the <i>Dothraki</i> trait).\n<em>Errata from FAQ v2.2</em>",
+            "text": "Limit 1 copy per character.\nWhile attached character is attacking, it gets +1 STR (+3 STR instead if it has the <i>Dothraki</i> trait).",
             "deckLimit": 3,
-            "illustrator": "Carlos Palma Cruchaga"
+            "illustrator": "Carlos Palma Cruchaga",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "While attached character is attacking, it gets +1 STR (+3 STR instead if it has the <i>Dothraki</i> trait).",
+                    "notes": null
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "2.2",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "Limit 1 copy per character.\nWhile attached character is attacking, it gets +1 STR (+3 STR instead if it has the <i>Dothraki</i> trait).",
+                    "notes": "Should read: \"Limit 1 copy per character.\""
+                }
+            ]
         },
         {
             "code": "14037",

--- a/packs/KotI.json
+++ b/packs/KotI.json
@@ -22,9 +22,24 @@
                 "Ironborn",
                 "Lord"
             ],
-            "text": "Pillage. Renown.\n<b>Action:</b> Kneel your faction card to choose a card in an opponent's discard pile and put it into play under your control. At the end of the phase, if that card is still in play, shuffle it into its owner's deck.\n<em>Errata from FAQ v2.0</em>",
+            "text": "Pillage. Renown.\n<b>Action:</b> Kneel your faction card to choose a card in an opponent's discard pile and put it into play under your control. At the end of the phase, if that card is still in play, shuffle it into its owner's deck.",
             "deckLimit": 3,
-            "illustrator": "Michele Frigo"
+            "illustrator": "Michele Frigo",
+            "errata": [
+                {
+                    "issuer" : "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "Pillage. Renown.\n<b>Action:</b> Kneel your faction card to choose a card in an opponent's discard pile and put it into play under your control. At the end of the phase shuffle it into its owner's deck.",
+                    "notes": null
+                },
+                {
+                    "issuer" : "Fantasy Flight Games",
+                    "version": "2.0",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "Pillage. Renown.\n<b>Action:</b> Kneel your faction card to choose a card in an opponent's discard pile and put it into play under your control. At the end of the phase, if that card is still in play, shuffle it into its owner's deck.",
+                    "notes": "Should read: \"...At the end of the phase, if that card is still in play, shuffle it into its owner’s deck.\""
+                }
+            ]
         },
         {
             "code": "12002",

--- a/packs/LoCR.json
+++ b/packs/LoCR.json
@@ -546,9 +546,24 @@
             "traits": [
                 "Iron Islands"
             ],
-            "text": "<b>Reaction:</b> After you initiate a [power] challenge, kneel Old Wyk to put the top <i>Drowned God</i> character in your dead pile into play knelt, participating as an attacker. Then, if you win the challenge by 5 or more STR, return that character to your hand. Otherwise, place it on the bottom of your deck.\n<em>Errata from FAQ v2.0</em>",
+            "text": "<b>Reaction:</b> After you initiate a [power] challenge, kneel Old Wyk to put the top <i>Drowned God</i> character in your dead pile into play knelt, participating as an attacker. Then, if you win the challenge by 5 or more STR, return that character to your hand. Otherwise, place it on the bottom of your deck.",
             "deckLimit": 3,
-            "illustrator": "Juan Carlos Barquet"
+            "illustrator": "Juan Carlos Barquet",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "<b>Reaction:</b> After you initiate a [power] challenge, kneel Old Wyk to put the top <i>Drowned God</i> character in your dead pile into play knelt, participating as an attacker. If you win the challenge by 5 or more STR, return that character to your hand. Otherwise, place it on the bottom of your deck.",
+                    "notes": null
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "2.0",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "<b>Reaction:</b> After you initiate a [power] challenge, kneel Old Wyk to put the top <i>Drowned God</i> character in your dead pile into play knelt, participating as an attacker. Then, if you win the challenge by 5 or more STR, return that character to your hand. Otherwise, place it on the bottom of your deck.",
+                    "notes": "Should read: \"...Then, if you win the challenge by 5 or more STR, return that character to your hand. Otherwise, place it on the bottom of your deck.\""
+                }
+            ]
         },
         {
             "code": "05029",

--- a/packs/NMG.json
+++ b/packs/NMG.json
@@ -66,7 +66,23 @@
             "text": "<b>Reaction:</b> After Ser Horas Redwyne is knelt, choose and stand a <i>Lady</i> character.",
             "flavor": "Arya had seen them in the bailey a hundred times; the Redwyne twins, Ser Horas and Ser Hobber, homely youths with orange hair and square, freckled faces.",
             "deckLimit": 3,
-            "illustrator": "Joshua Cairós"
+            "illustrator": "Joshua Cairós",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "<b>Reaction:</b> After Ser Horas Redwyne is knelt, choose and stand a Lady character.",
+                    "notes": null
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "1.0",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "<b>Reaction:</b> After Ser Horas Redwyne is knelt, choose and stand a <i>Lady</i> character.",
+                    "notes": "Should read: \"...choose and stand a <i>Lady</i> character.\""
+                }
+            ]
+
         },
         {
             "code": "02064",

--- a/packs/SAT.json
+++ b/packs/SAT.json
@@ -217,9 +217,24 @@
                 "Drowned God",
                 "Weapon"
             ],
-            "text": "<i>Drowned God</i> character only.\nAttached character gets +1 STR for each character in your dead pile.\n<b>Interrupt:</b> When attached character is killed, move Driftwood Cudgel to another eligible character. That character gains 1 power. (Limit once per phase.)\n<em>Errata from FAQ v1.4</em>",
+            "text": "<i>Drowned God</i> character only.\nAttached character gets +1 STR for each character in your dead pile.\n<b>Interrupt:</b> When attached character is killed, move Driftwood Cudgel to another eligible character. That character gains 1 power. (Limit once per phase.)",
             "deckLimit": 3,
-            "illustrator": "Sara Biddle"
+            "illustrator": "Sara Biddle",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "<i>Drowned God</i> character only.\nAttached character gets +1 STR for each character in your dead pile.\n<b>Interrupt:</b> When attached character is killed, move Driftwood Cudgel to another eligible character. That character gains 1 power.",
+                    "notes": null
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "1.4",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "<i>Drowned God</i> character only.\nAttached character gets +1 STR for each character in your dead pile.\n<b>Interrupt:</b> When attached character is killed, move Driftwood Cudgel to another eligible character. That character gains 1 power. (Limit once per phase.)",
+                    "notes": "Interrupt ability should have the text: \"(Limit once per phase.)\""
+                }
+            ]
         },
         {
             "code": "08113",
@@ -253,9 +268,24 @@
             "traits": [
                 "Prophecy"
             ],
-            "text": "<b>Dominance Action:</b> Each player may shuffle his or her hand (of at least 1 card) into his or her deck. Each player that does draws 5 cards.\n<em>Errata from FAQ v1.4</em>",
+            "text": "<b>Dominance Action:</b> Each player may shuffle his or her hand (of at least 1 card) into his or her deck. Each player that does draws 5 cards.",
             "deckLimit": 3,
-            "illustrator": "Kristina Carroll"
+            "illustrator": "Kristina Carroll",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "<b>Dominance Action:</b> Each player may shuffle his or her hand (of at least 1 card) into his or her deck to draw 5 cards.",
+                    "notes": null
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "1.4",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "<b>Dominance Action:</b> Each player may shuffle his or her hand (of at least 1 card) into his or her deck. Each player that does draws 5 cards.",
+                    "notes": "Should read: \"<b>Dominance Action:</b> Each player may shuffle his or her hand (of at least 1 card) into his or her deck. Each player that does draws 5 cards.\""
+                }
+            ]
         },
         {
             "code": "08115",

--- a/packs/TC.json
+++ b/packs/TC.json
@@ -206,9 +206,24 @@
             "traits": [
                 "Ironborn"
             ],
-            "text": "Stealth.\nIf you control Asha Greyjoy, sacrifice Esgred. Then, your Asha Greyjoy gains 1 power.\nEsgred may bypass an additional character using stealth.\n<em>Errata from FAQ v2.1</em>",
+            "text": "Stealth.\nIf you control Asha Greyjoy, sacrifice Esgred. Then, your Asha Greyjoy gains 1 power.\nEsgred may bypass an additional character using stealth.",
             "deckLimit": 3,
-            "illustrator": "Nicholas Gregory"
+            "illustrator": "Nicholas Gregory",
+            "errata": [
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "original",
+                    "text": "Stealth.\nIf you control Asha Greyjoy, sacrifice Esgred and have your Asha Greyjoy gains 1 power.\nEsgred may bypass an additional character using stealth.",
+                    "notes": null
+                },
+                {
+                    "issuer": "Fantasy Flight Games",
+                    "version": "2.1",
+                    "link": "https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf",
+                    "text": "Stealth.\nIf you control Asha Greyjoy, sacrifice Esgred. Then, your Asha Greyjoy gains 1 power.\nEsgred may bypass an additional character using stealth.",
+                    "notes": "Should read: \"If you control Asha Greyjoy, sacrifice Esgred. Then, your Asha Greyjoy gains 1 power.\""
+                }
+            ]
         },
         {
             "code": "04112",


### PR DESCRIPTION
fixes #76 

This is pretty much as discussed as in the referenced ticket, with the addition of a `notes` field. I took the values from the [FFG FAQ](https://images-cdn.fantasyflightgames.com/filer_public/7c/64/7c642fb4-cce0-4aae-8633-3a861d7727fd/agot_lcg_faq_30.pdf)'s "Card Errata" section.
This is much more free-form than tracking the actual card change-set (we're only doing title, for now), but i find this more descriptive and potentially more useful to the end-user.

I left the thronesdb-exporters/importers intentionally out, as they will hopefully soon be obsolete anyway. (will send a second PR if need be to adjust those as well). 

Please review, thanks!