### PR TITLE
adds the missing "by title" clause to the deck building restrictions.

### DIFF
--- a/packs/LMHR.json
+++ b/packs/LMHR.json
@@ -359,7 +359,7 @@
             "quantity": 3,
             "faction": "neutral",
             "traits": [],
-            "text": "Your minimum deck size is 75 cards. Your deck cannot include more than 1 copy of each attachment.\n<b>Action:</b> Kneel your faction card and pay X gold to put an attachment with printed cost X into play from your hand.\n<b>Reaction:</b> After an attachment enters play under your control, either: draw a card or gain 1 gold. (Limit 3 times per round.)",
+            "text": "Your minimum deck size is 75 cards. Your deck cannot include more than 1 copy of each attachment <em>(by title)</em>.\n<b>Action:</b> Kneel your faction card and pay X gold to put an attachment with printed cost X into play from your hand.\n<b>Reaction:</b> After an attachment enters play under your control, either: draw a card or gain 1 gold. (Limit 3 times per round.)",
             "designer": "Card design by 2015 Melee World Champion, Corey Faherty.",
             "deckLimit": 1,
             "illustrator": "Tim Durning"


### PR DESCRIPTION
usually, we can omit this kind of italicized text, but in this case we should have it - considering that the redesign of this agenda does away with this particular restriction. 