### PR TITLE
Add release date to Valyrian Draft cards

### DIFF
--- a/packs/VDS.json
+++ b/packs/VDS.json
@@ -2,7 +2,7 @@
     "cgdbId": null,
     "code": "VDS",
     "name": "Valyrian Draft Set",
-    "releaseDate": null,
+    "releaseDate": "2016-10-27",
     "cards": [
         {
             "code": "00001",


### PR DESCRIPTION
The date is based on the announcement article, which may not be 100% an
accurate date, but should be close enough for our purposes:
https://www.fantasyflightgames.com/en/news/2016/10/27/valyrian/