### PR TITLE
Fixing Core Banner images to "B" variant URL

### DIFF
--- a/packs/Core.json
+++ b/packs/Core.json
@@ -4094,7 +4094,8 @@
             "text": "You may include non-loyal [baratheon] cards in your deck.\nYou must include at least 12 [baratheon] cards in your deck.",
             "flavor": "\"I never asked for Dragonstone. I never wanted it.\" <cite>Stannis Baratheon</cite>",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_198B.jpg"
         },
         {
             "code": "01199",
@@ -4109,7 +4110,8 @@
             "text": "You may include non-loyal [greyjoy] cards in your deck.\nYou must include at least 12 [greyjoy] cards in your deck.",
             "flavor": "\"Greyjoy demands half the kingdom as the price of alliance, but what will he do to earn it?\" <cite>Tywin Lannister</cite>",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_199B.jpg"
         },
         {
             "code": "01200",
@@ -4123,7 +4125,8 @@
             ],
             "text": "You may include non-loyal [lannister] cards in your deck.\nYou must include at least 12 [lannister] cards in your deck.",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_200B.jpg"
         },
         {
             "code": "01201",
@@ -4137,7 +4140,8 @@
             ],
             "text": "You may include non-loyal [martell] cards in your deck.\nYou must include at least 12 [martell] cards in your deck.",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_201B.jpg"
         },
         {
             "code": "01202",
@@ -4151,7 +4155,8 @@
             ],
             "text": "You may include non-loyal [thenightswatch] cards in your deck.\nYou must include at least 12 [thenightswatch] cards in your deck.",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_202B.jpg"
         },
         {
             "code": "01203",
@@ -4165,7 +4170,8 @@
             ],
             "text": "You may include non-loyal [stark] cards in your deck.\nYou must include at least 12 [stark] cards in your deck.",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_203B.jpg"
         },
         {
             "code": "01204",
@@ -4179,7 +4185,8 @@
             ],
             "text": "You may include non-loyal [targaryen] cards in your deck.\nYou must include at least 12 [targaryen] cards in your deck.",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_204B.jpg"
         },
         {
             "code": "01205",
@@ -4193,7 +4200,8 @@
             ],
             "text": "You may include non-loyal [tyrell] cards in your deck.\nYou must include at least 12 [tyrell] cards in your deck.",
             "deckLimit": 1,
-            "illustrator": "David Griffith"
+            "illustrator": "David Griffith",
+            "imageUrl": "https://lcg-cdn.fantasyflightgames.com/got2nd/GT01_205B.jpg"
         },
         {
             "code": "01206",


### PR DESCRIPTION
This should fix Banner cards from not being loaded in with the `fetchdata.js` script.