### PR TITLE
updates link to GOT RL 1.6 Joust PDF.

### DIFF
--- a/restricted-list.json
+++ b/restricted-list.json
@@ -4483,7 +4483,7 @@
         "formats": [
             {
                 "name": "joust",
-                "url": "https://agot.cards/wp-content/uploads/2023/01/RL-Standard-Joust-1.6-2023-1.pdf",
+                "url": "https://agot.cards/wp-content/uploads/2023/01/RL-Standard-Joust-1.6-2023-1.1.pdf",
                 "restricted": [
                     "01146",
                     "02026",


### PR DESCRIPTION
the previously linked version had an omission in it, Will uploaded this corrected version this morning.

this has been patched into TDB already, so no rush on this.