### PR TITLE
updates RL v1.12 for Melee.

### DIFF
--- a/restricted-list.json
+++ b/restricted-list.json
@@ -6745,7 +6745,9 @@
                         ]
                     }
                 ],
-                "banned": []
+                "banned": [
+                    "25100"
+                ]
             }
         ],
         "bannedCards": [

--- a/restricted-list.json
+++ b/restricted-list.json
@@ -6647,7 +6647,7 @@
             },
             {
                 "name": "melee",
-                "url": "https://agot.cards/wp-content/uploads/2024/10/GOT_Card_Legality_v1.12_Melee.pdf",
+                "url": "https://agot.cards/wp-content/uploads/2024/11/GOT-Card-Legality-v1.12-Melee.pdf",
                 "restricted": [
                     "01001",
                     "01013",


### PR DESCRIPTION
- updates the link to the PDF version of this RL (the previous version omitted Pod 5)
- adds "The Last Greenseer" to the list of banned cards for melee (my oversight)